### PR TITLE
docs: fix enterprise typo

### DIFF
--- a/old/tasks/utils.yaml
+++ b/old/tasks/utils.yaml
@@ -33,7 +33,7 @@ spec:
   params:
     - name: GITHUB_HOST_URL
       description: |
-        The GitHub host, adjust this if you run a GitHub enteprise.
+        The GitHub host, adjust this if you run a GitHub enterprise.
       default: "api.github.com"
       type: string
 


### PR DESCRIPTION
## Problem
The nightly typo checker reported `enteprise` in `old/tasks/utils.yaml`.

## Solution
Correct `enteprise` to `enterprise` in the GitHub host description.

## Validation
- Verified `enteprise` no longer appears in `old/tasks/utils.yaml`
- Ran `git diff --check`

Confidence: 85/100 (typo fix)

Closes #25
